### PR TITLE
Fixes small typo in accusations list

### DIFF
--- a/lib/modules/accusation.js
+++ b/lib/modules/accusation.js
@@ -1,7 +1,7 @@
 const accusations = [
   '{user} {predicate} a spy', '{user} {predicate} innocent', '{user} {predicate} the commander',
   '{user} {predicate} the body guard', '{user} {predicate} the assassin', '{user} {predicate} a commander',
-  '{user] {predicate} playing like a blind spy', '{user} {predicate} evil', '{user} {predicate} good',
+  '{user} {predicate} playing like a blind spy', '{user} {predicate} evil', '{user} {predicate} good',
   '{user} {predicate} an accuser', '{user} {predicate} a reverser', '{user} {predicate} clearly a defector'
 ];
 


### PR DESCRIPTION
Fixes small typo in accusations list:  

`'{user] {predicate} playing like a blind spy'`
